### PR TITLE
Added module include_one which fixes the issue of loading multiple configs

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -142,6 +142,7 @@ sway_cmd cmd_fullscreen;
 sway_cmd cmd_gaps;
 sway_cmd cmd_hide_edge_borders;
 sway_cmd cmd_include;
+sway_cmd cmd_include_one;
 sway_cmd cmd_inhibit_idle;
 sway_cmd cmd_input;
 sway_cmd cmd_seat;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -103,6 +103,7 @@ static const struct cmd_handler handlers[] = {
 static const struct cmd_handler config_handlers[] = {
 	{ "default_orientation", cmd_default_orientation },
 	{ "include", cmd_include },
+	{ "include_one", cmd_include_one},
 	{ "swaybg_command", cmd_swaybg_command },
 	{ "swaynag_command", cmd_swaynag_command },
 	{ "workspace_layout", cmd_workspace_layout },

--- a/sway/commands/include_one.c
+++ b/sway/commands/include_one.c
@@ -39,10 +39,10 @@ void priority_configs(const char *path, const char *parent_dir, struct sway_conf
 			config_loc->name =  basename(matched_path);
 			config_loc->path = matched_path;
 			if (index == -1) {
-				list_add(locations, &config_loc);
+				list_add(locations, config_loc);
 				continue;
 			}
-			locations->items[index] = &config_loc; 
+			locations->items[index] = config_loc; 
 		}
 	}
 
@@ -53,7 +53,6 @@ void priority_configs(const char *path, const char *parent_dir, struct sway_conf
 	}
 cleanup:
 	free(wd);
-	list_free_items_and_destroy(locations);
 }
 
 struct cmd_results *cmd_include_one(int argc, char **argv) {
@@ -75,6 +74,6 @@ struct cmd_results *cmd_include_one(int argc, char **argv) {
 	for(int i=0; i<locs->length; ++i) {
 		load_include_configs (locs_arr[i]->path, config, &config->swaynag_config_errors);
 	}
-	list_free(locs);
+	list_free_items_and_destroy(locs);
 	return cmd_results_new(CMD_SUCCESS, NULL);
 }

--- a/sway/commands/include_one.c
+++ b/sway/commands/include_one.c
@@ -1,0 +1,78 @@
+#define _XOPEN_SOURCE 700 
+#include "sway/commands.h"
+#include "sway/config.h"
+#include "list.h"
+#include "log.h"
+#include "unistd.h"
+#include <string.h>
+#include <libgen.h>
+#include <wordexp.h>
+
+typedef struct {
+	char *name;
+	char *path;
+} config_location_map;
+
+int compare_paths(const config_location_map* item, char* abspath) {
+	if (strcmp(item->name, basename(abspath))==0) {
+		return 0;
+	}
+	return -1;
+}
+
+void priority_configs(const char *path, const char *parent_dir, struct sway_config *config, list_t *locations) {
+	char *wd = getcwd(NULL, 0);
+
+	if (chdir(parent_dir) < 0) {
+		sway_log(SWAY_ERROR, "failed to change working directory");
+		goto cleanup;
+	}
+
+	wordexp_t p;
+	if (wordexp(path, &p, 0) == 0) {
+		char **w = p.we_wordv;
+		size_t i;
+		for (i = 0; i < p.we_wordc; ++i) {
+			int index = list_seq_find(locations, (int (*)(const void *, const void *))compare_paths, w[i]);
+			char* matched_path = strdup(w[i]);
+			config_location_map config_loc = {basename(matched_path), matched_path};
+			if (index == -1) {
+				list_add(locations, &config_loc);
+				continue;
+			}
+			locations->items[index] = &config_loc; 
+		}
+	}
+
+	wordfree(&p);
+	
+	if (chdir(wd) < 0) {
+		sway_log(SWAY_ERROR, "failed to change working directory");
+	}
+cleanup:
+	free(wd);
+}
+
+struct cmd_results *cmd_include_one(int argc, char **argv) {
+
+	struct cmd_results *error = NULL;
+	char *parent_path = strdup(config->current_config_path);
+	const char *parent_dir = dirname(parent_path);
+	list_t *locs = create_list();
+	
+	if ((error = checkarg(argc, "include_one", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	
+	for(int i=0; i<argc ; ++i){
+		priority_configs(argv[i], parent_dir, config, locs);
+		sway_log(SWAY_ERROR, "PARSING INCLUDE PATH: %s", argv[i]);
+	}
+
+	config_location_map **locs_arr = (config_location_map**) locs->items;
+	for(int i=0; i<locs->length; ++i) {
+		load_include_configs (locs_arr[i]->path, config, &config->swaynag_config_errors);
+	}
+	list_free(locs);
+	return cmd_results_new(CMD_SUCCESS, NULL);
+}

--- a/sway/commands/include_one.c
+++ b/sway/commands/include_one.c
@@ -35,7 +35,9 @@ void priority_configs(const char *path, const char *parent_dir, struct sway_conf
 		for (i = 0; i < p.we_wordc; ++i) {
 			int index = list_seq_find(locations, (int (*)(const void *, const void *))compare_paths, w[i]);
 			char* matched_path = strdup(w[i]);
-			config_location_map config_loc = {basename(matched_path), matched_path};
+			config_location_map* config_loc = malloc(sizeof(config_location_map));
+			config_loc->name =  basename(matched_path);
+			config_loc->path = matched_path;
 			if (index == -1) {
 				list_add(locations, &config_loc);
 				continue;
@@ -51,6 +53,7 @@ void priority_configs(const char *path, const char *parent_dir, struct sway_conf
 	}
 cleanup:
 	free(wd);
+	list_free_items_and_destroy(locations);
 }
 
 struct cmd_results *cmd_include_one(int argc, char **argv) {
@@ -66,7 +69,6 @@ struct cmd_results *cmd_include_one(int argc, char **argv) {
 	
 	for(int i=0; i<argc ; ++i){
 		priority_configs(argv[i], parent_dir, config, locs);
-		sway_log(SWAY_ERROR, "PARSING INCLUDE PATH: %s", argv[i]);
 	}
 
 	config_location_map **locs_arr = (config_location_map**) locs->items;

--- a/sway/meson.build
+++ b/sway/meson.build
@@ -72,6 +72,7 @@ sway_sources = files(
 	'commands/max_render_time.c',
 	'commands/opacity.c',
 	'commands/include.c',
+	'commands/include_one.c',
 	'commands/input.c',
 	'commands/layout.c',
 	'commands/mode.c',


### PR DESCRIPTION
### Sway configuration override
A configuration option that sway has (and i3 as well) is to include partial configuration files from directories.
The issue being it first imports the global configuration, then the user configuration, which often overlaps. 
To avoid overlap, the user manually needs to delete the earlier default package and install the custom one.

To resolve this issue, I have created one config command called `include_one`, with the syntax:  `include_one path1 path2 path3 ...` and as you keep including paths, the priority of the paths increases sequentially. 
Configurations with higher priorities having the same file name would be selected.

Example of usage of include_one command:
`include_one /usr/share/regolith/sway/config.d/* $HOME/.config/regolith2/sway/config.d/* `
Here if there is a config file in both the paths with the same name, then the config file of the path `$HOME/.config/regolith2/sway/config.d/*` will be getting priority and will be loaded.

### Testing
To test this functionality, I  created two config files with the same name in different directories. Both the config partials contained the same keybinding but with different functionality. I used the command include_one in the sway root config and supplied it as an argument to sway-regolith with this patch applied. As expected, the key binding mapped to the functionality specified in the config file with the higher priority.