### PR TITLE
fix: use Provides for sway instead of Conflicts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Architecture: any
 Depends: libgl1-mesa-dri, swaybg, policykit-1, libtrawldb, ${misc:Depends}, ${shlibs:Depends}
 Recommends: suckless-tools, sway-backgrounds, foot
 Suggests: swayidle, swaylock, xdg-desktop-portal-wlr
-Conflicts: sway
+Provides: sway
 Description: i3-compatible Wayland compositor for the Regolith desktop environment
  sway (SirCmpwn's Wayland compositor) is a tiling Wayland compositor and a
  drop-in replacement for the i3 window manager for X11. It works with your


### PR DESCRIPTION
This is required to ensure the packages that depend on sway to remain installable due to sway-regolith providing it as a virtual package. A good example of such a package is grimshot which is  screenshot app created by the sway creators.