### PR TITLE
fix: isolate files shared with upstream in supplemental package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sway-regolith (1.9-13) noble; urgency=medium
+sway-regolith (1.9-14) noble; urgency=medium
 
   * fix: isolate files shared with upstream in supplemental package
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sway-regolith (1.9-9) noble; urgency=medium
+sway-regolith (1.9-10) noble; urgency=medium
 
   * fix: isolate files shared with upstream in supplemental package
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sway-regolith (1.9-6) noble; urgency=medium
+
+  * fix: isolate files shared with upstream in supplemental package
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Sat, 18 May 2024 08:47:20 -0700
+
 sway-regolith (1.9-5) noble; urgency=medium
 
   [ Soumya Ranjan Patnaik ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sway-regolith (1.9-10) noble; urgency=medium
+sway-regolith (1.9-11) noble; urgency=medium
 
   * fix: isolate files shared with upstream in supplemental package
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sway-regolith (1.9-6) noble; urgency=medium
+sway-regolith (1.9-7) noble; urgency=medium
 
   * fix: isolate files shared with upstream in supplemental package
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sway-regolith (1.9-7) noble; urgency=medium
+sway-regolith (1.9-8) noble; urgency=medium
 
   * fix: isolate files shared with upstream in supplemental package
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sway-regolith (1.9-12) noble; urgency=medium
+sway-regolith (1.9-13) noble; urgency=medium
 
   * fix: isolate files shared with upstream in supplemental package
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sway-regolith (1.9-8) noble; urgency=medium
+sway-regolith (1.9-9) noble; urgency=medium
 
   * fix: isolate files shared with upstream in supplemental package
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sway-regolith (1.9-11) noble; urgency=medium
+sway-regolith (1.9-12) noble; urgency=medium
 
   * fix: isolate files shared with upstream in supplemental package
 

--- a/debian/control
+++ b/debian/control
@@ -49,7 +49,6 @@ Description: i3-compatible Wayland compositor for the Regolith desktop environme
 
 Package: sway-regolith-supplemental
 Architecture: any
-Priority: standard
 Depends: libgl1-mesa-dri, ${misc:Depends}, ${shlibs:Depends}
 Provides: sway
 Conflicts: sway

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Depends:
     sway-regolith-supplemental | sway (>= 1.9),
     ${misc:Depends},
     ${shlibs:Depends}
-Suggests: xdg-desktop-portal-wlr, sway-regolith-supplemental
+Suggests: xdg-desktop-portal-wlr
 Description: i3-compatible Wayland compositor for the Regolith desktop environment
  sway (SirCmpwn's Wayland compositor) is a tiling Wayland compositor and a
  drop-in replacement for the i3 window manager for X11. It works with your
@@ -49,24 +49,19 @@ Description: i3-compatible Wayland compositor for the Regolith desktop environme
 
 Package: sway-regolith-supplemental
 Architecture: any
-Priority: standard
 Depends: libgl1-mesa-dri, ${misc:Depends}, ${shlibs:Depends}
-Provides: sway
 Conflicts: sway
-Replaces: sway
 Description: Support files that may also come from upstream package
  These files are required for sway to function but may be provided by upstream.
 
 Package: sway-regolith-standalone
 Architecture: any
-Priority: standard
 Depends: sway-regolith, sway-regolith-supplemental, ${misc:Depends}, ${shlibs:Depends}
 Description: Meta package for Regolith's Sway variant.
  This meta package is for systems that do not use baseline Sway.
 
 Package: sway-regolith-hybrid
 Architecture: any
-Priority: standard
 Depends: sway-regolith, sway, ${misc:Depends}, ${shlibs:Depends}
 Description: Meta package for Regolith's Sway variant.
  This meta package is for systems that also have baseline Sway installed.

--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Depends:
     swaybg,
     polkitd,
     libtrawldb,
-    sway (>= 1.9) | sway-regolith-supplemental,
+    sway-regolith-supplemental | sway (>= 1.9),
     ${misc:Depends},
     ${shlibs:Depends}
 Suggests: xdg-desktop-portal-wlr
@@ -49,6 +49,7 @@ Description: i3-compatible Wayland compositor for the Regolith desktop environme
 
 Package: sway-regolith-supplemental
 Architecture: any
+Priority: standard
 Depends: libgl1-mesa-dri, ${misc:Depends}, ${shlibs:Depends}
 Provides: sway
 Conflicts: sway

--- a/debian/control
+++ b/debian/control
@@ -49,6 +49,7 @@ Description: i3-compatible Wayland compositor for the Regolith desktop environme
 
 Package: sway-regolith-supplemental
 Architecture: any
+Priority: standard
 Depends: libgl1-mesa-dri, ${misc:Depends}, ${shlibs:Depends}
 Provides: sway
 Conflicts: sway

--- a/debian/control
+++ b/debian/control
@@ -39,9 +39,7 @@ Depends:
     sway-regolith-supplemental | sway (>= 1.9),
     ${misc:Depends},
     ${shlibs:Depends}
-Recommends:
-    sway-regolith-supplemental
-Suggests: xdg-desktop-portal-wlr
+Suggests: xdg-desktop-portal-wlr, sway-regolith-supplemental
 Description: i3-compatible Wayland compositor for the Regolith desktop environment
  sway (SirCmpwn's Wayland compositor) is a tiling Wayland compositor and a
  drop-in replacement for the i3 window manager for X11. It works with your

--- a/debian/control
+++ b/debian/control
@@ -39,6 +39,8 @@ Depends:
     sway-regolith-supplemental | sway (>= 1.9),
     ${misc:Depends},
     ${shlibs:Depends}
+Recommends:
+    sway-regolith-supplemental
 Suggests: xdg-desktop-portal-wlr
 Description: i3-compatible Wayland compositor for the Regolith desktop environment
  sway (SirCmpwn's Wayland compositor) is a tiling Wayland compositor and a
@@ -56,3 +58,17 @@ Conflicts: sway
 Replaces: sway
 Description: Support files that may also come from upstream package
  These files are required for sway to function but may be provided by upstream.
+
+Package: sway-regolith-standalone
+Architecture: any
+Priority: standard
+Depends: sway-regolith, sway-regolith-supplemental, ${misc:Depends}, ${shlibs:Depends}
+Description: Meta package for Regolith's Sway variant.
+ This meta package is for systems that do not use baseline Sway.
+
+Package: sway-regolith-hybrid
+Architecture: any
+Priority: standard
+Depends: sway-regolith, sway, ${misc:Depends}, ${shlibs:Depends}
+Description: Meta package for Regolith's Sway variant.
+ This meta package is for systems that also have baseline Sway installed.

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Depends:
     sway-regolith-supplemental | sway (>= 1.9),
     ${misc:Depends},
     ${shlibs:Depends}
-Suggests: xdg-desktop-portal-wlr
+Suggests: xdg-desktop-portal-wlr, sway-regolith-supplemental
 Description: i3-compatible Wayland compositor for the Regolith desktop environment
  sway (SirCmpwn's Wayland compositor) is a tiling Wayland compositor and a
  drop-in replacement for the i3 window manager for X11. It works with your
@@ -53,15 +53,3 @@ Depends: libgl1-mesa-dri, ${misc:Depends}, ${shlibs:Depends}
 Conflicts: sway
 Description: Support files that may also come from upstream package
  These files are required for sway to function but may be provided by upstream.
-
-Package: sway-regolith-standalone
-Architecture: any
-Depends: sway-regolith, sway-regolith-supplemental, ${misc:Depends}, ${shlibs:Depends}
-Description: Meta package for Regolith's Sway variant.
- This meta package is for systems that do not use baseline Sway.
-
-Package: sway-regolith-hybrid
-Architecture: any
-Depends: sway-regolith, sway, ${misc:Depends}, ${shlibs:Depends}
-Description: Meta package for Regolith's Sway variant.
- This meta package is for systems that also have baseline Sway installed.

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,7 @@
 Source: sway-regolith
 Section: x11
 Priority: optional
-Maintainer: Sway and related packages team <team+swaywm@tracker.debian.org>
-Uploaders: Birger Schacht <birger@debian.org>,
-           nicoo <nicoo@debian.org>
+Maintainer: Regolith Desktop <regolith.desktop@gmail.com>
 Build-Depends: debhelper-compat (= 13),
                libcairo2-dev,
                libcap-dev,
@@ -29,19 +27,31 @@ Build-Depends: debhelper-compat (= 13),
                tree,
                wayland-protocols (>= 1.24)
 Standards-Version: 4.6.1.0
-Homepage: http://swaywm.org
-Vcs-Browser: https://salsa.debian.org/swaywm-team/sway
-Vcs-Git: https://salsa.debian.org/swaywm-team/sway.git
 Rules-Requires-Root: no
 
 Package: sway-regolith
 Architecture: any
-Depends: libgl1-mesa-dri, swaybg, policykit-1, libtrawldb, ${misc:Depends}, ${shlibs:Depends}
+Depends:
+    libgl1-mesa-dri,
+    swaybg,
+    polkitd,
+    libtrawldb,
+    sway (>= 1.9) | sway-regolith-supplemental,
+    ${misc:Depends},
+    ${shlibs:Depends}
 Suggests: xdg-desktop-portal-wlr
-Provides: sway
 Description: i3-compatible Wayland compositor for the Regolith desktop environment
  sway (SirCmpwn's Wayland compositor) is a tiling Wayland compositor and a
  drop-in replacement for the i3 window manager for X11. It works with your
  existing i3 configuration and supports most of i3's features, plus a few
  extras. This means it is a minimalist, tiling window manager.  This variant
  supports trawl integration.
+
+Package: sway-regolith-supplemental
+Architecture: any
+Depends: libgl1-mesa-dri, ${misc:Depends}, ${shlibs:Depends}
+Provides: sway
+Conflicts: sway
+Replaces: sway
+Description: Support files that may also come from upstream package
+ These files are required for sway to function but may be provided by upstream.

--- a/debian/control
+++ b/debian/control
@@ -39,7 +39,7 @@ Depends:
     sway-regolith-supplemental | sway (>= 1.9),
     ${misc:Depends},
     ${shlibs:Depends}
-Suggests: xdg-desktop-portal-wlr, sway-regolith-supplemental
+Suggests: xdg-desktop-portal-wlr
 Description: i3-compatible Wayland compositor for the Regolith desktop environment
  sway (SirCmpwn's Wayland compositor) is a tiling Wayland compositor and a
  drop-in replacement for the i3 window manager for X11. It works with your

--- a/debian/sway-regolith-supplemental.install
+++ b/debian/sway-regolith-supplemental.install
@@ -1,0 +1,4 @@
+usr/bin/swaybar
+usr/bin/swaymsg
+usr/bin/swaynag
+usr/share/

--- a/debian/sway-regolith.install
+++ b/debian/sway-regolith.install
@@ -1,0 +1,1 @@
+usr/bin/sway-regolith


### PR DESCRIPTION
See https://github.com/regolith-linux/sway-regolith/pull/21#issuecomment-2118846157
